### PR TITLE
Add safe display pricing and tokenized item search

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "nodemon src/server.js",
     "start": "node src/server.js",
+    "debug:item": "node scripts/debug-item.js",
     "lint": "eslint .",
     "format": "prettier --write ."
   },

--- a/backend/scripts/debug-item.js
+++ b/backend/scripts/debug-item.js
@@ -1,0 +1,102 @@
+require("dotenv").config();
+
+const pool = require("../src/db/pool");
+const { getPriceDisplay } = require("../src/services/priceDisplay.service");
+
+const search =
+  process.argv.slice(2).join(" ").trim() ||
+  "Sticker | FlyQuest (Holo) | Budapest 2025";
+const searchTokens = search.split(/\s+/).filter(Boolean);
+
+async function main() {
+  const whereParts = searchTokens.map((_, index) => {
+    return `i.market_hash_name ILIKE $${index + 1}`;
+  });
+  const searchValues = searchTokens.map((token) => `%${token}%`);
+
+  const itemResult = await pool.query(
+    `
+      SELECT
+        i.id,
+        i.market_hash_name,
+        i.item_type,
+        i.rarity,
+        i.weapon,
+        i.exterior,
+        i.image_url,
+        l.as_of AS latest_as_of,
+        l.min_price AS latest_min_price,
+        l.suggested_price AS latest_suggested_price,
+        l.quantity AS latest_quantity,
+        l.raw AS latest_raw
+      FROM items i
+      LEFT JOIN item_latest l ON l.item_id = i.id
+      ${whereParts.length ? `WHERE ${whereParts.join(" AND ")}` : ""}
+      ORDER BY i.market_hash_name
+      LIMIT 25;
+    `,
+    searchValues
+  );
+
+  const ids = itemResult.rows.map((row) => row.id);
+
+  let historyRows = [];
+  if (ids.length > 0) {
+    const historyResult = await pool.query(
+      `
+        SELECT
+          h.item_id,
+          i.market_hash_name,
+          h.as_of,
+          h.min_price,
+          h.suggested_price,
+          h.quantity,
+          h.raw
+        FROM item_price_history h
+        JOIN items i ON i.id = h.item_id
+        WHERE h.item_id = ANY($1::bigint[])
+        ORDER BY h.as_of DESC
+        LIMIT 50;
+      `,
+      [ids]
+    );
+
+    historyRows = historyResult.rows;
+  }
+
+  const items = itemResult.rows.map((row) => ({
+    ...row,
+    ...getPriceDisplay({
+      min_price: row.latest_min_price,
+      suggested_price: row.latest_suggested_price,
+      quantity: row.latest_quantity,
+    }),
+  }));
+
+  const recentHistory = historyRows.map((row) => ({
+    ...row,
+    ...getPriceDisplay(row),
+  }));
+
+  console.log(
+    JSON.stringify(
+      {
+        search,
+        item_count: itemResult.rowCount,
+        items,
+        recent_history: recentHistory,
+      },
+      null,
+      2
+    )
+  );
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await pool.end();
+  });

--- a/backend/src/db/items.repository.js
+++ b/backend/src/db/items.repository.js
@@ -19,7 +19,7 @@ async function upsertItemMetadata(client, item) {
       rarity_rank = EXCLUDED.rarity_rank,
       weapon = EXCLUDED.weapon,
       exterior = EXCLUDED.exterior,
-      image_url = EXCLUDED.image_url
+      image_url = COALESCE(EXCLUDED.image_url, items.image_url)
     RETURNING id, market_hash_name;
   `;
 

--- a/backend/src/routes/items.routes.js
+++ b/backend/src/routes/items.routes.js
@@ -3,8 +3,43 @@
 //Supports search + returns 'pages' to avoid sending full dataset.
 const express = require("express");
 const pool = require("../db/pool");
+const {
+  getDisplayPriceSql,
+  getPriceDisplay,
+} = require("../services/priceDisplay.service");
 
 const router = express.Router();
+const DISPLAY_PRICE_SQL = getDisplayPriceSql("l");
+
+const SORT_COLUMNS = {
+  price: DISPLAY_PRICE_SQL,
+  name: "i.market_hash_name",
+  quantity: "l.quantity",
+  updated: "l.as_of",
+};
+
+function parseSortParams(query) {
+  const rawSort = (query.sort || "price").toString().trim().toLowerCase();
+  const rawOrder = (query.order || "").toString().trim().toLowerCase();
+
+  if (rawSort === "price_asc") {
+    return { sort: "price", order: "asc", orderBy: `${DISPLAY_PRICE_SQL} ASC NULLS LAST` };
+  }
+
+  if (rawSort === "price_desc") {
+    return { sort: "price", order: "desc", orderBy: `${DISPLAY_PRICE_SQL} DESC NULLS LAST` };
+  }
+
+  const sort = SORT_COLUMNS[rawSort] ? rawSort : "price";
+  const order = rawOrder === "desc" ? "desc" : "asc";
+  const direction = order.toUpperCase();
+
+  return {
+    sort,
+    order,
+    orderBy: `${SORT_COLUMNS[sort]} ${direction} NULLS LAST`,
+  };
+}
 
 router.get("/items", async (req, res, next) => {
   try {
@@ -19,14 +54,16 @@ router.get("/items", async (req, res, next) => {
     const maxPrice = req.query.maxPrice !== undefined ? Number(req.query.maxPrice) : null;
     const rawStatus = (req.query.status || "active").toString().trim().toLowerCase();
     const status = ["active", "all", "stale"].includes(rawStatus) ? rawStatus : "active";
+    const sortParams = parseSortParams(req.query);
 
     const where = [];
     const values = [];
     let param = 1;
 
-    if (q) {
+    const searchTokens = q.split(/\s+/).filter(Boolean);
+    for (const token of searchTokens) {
       where.push(`i.market_hash_name ILIKE $${param++}`);
-      values.push(`%${q}%`);
+      values.push(`%${token}%`);
     }
 
     if (weapon) {
@@ -94,7 +131,7 @@ router.get("/items", async (req, res, next) => {
         (latest_snapshot.item_id IS NOT NULL) AS is_active
       ${baseFrom}
       ${whereClause}
-      ORDER BY l.min_price ASC NULLS LAST
+      ORDER BY ${sortParams.orderBy}
       LIMIT $${param++}
       OFFSET $${param++}
     `;
@@ -109,20 +146,34 @@ router.get("/items", async (req, res, next) => {
       FROM item_price_history
     `);
 
-    const items = dataResult.rows.map((row) => ({
-      market_hash_name: row.market_hash_name,
-      min_price: row.min_price === null ? null : Number(row.min_price),
-      suggested_price: row.suggested_price === null ? null : Number(row.suggested_price),
-      quantity: row.quantity,
-      image_url: row.image_url,
-      weapon: row.weapon,
-      exterior: row.exterior,
-      as_of: row.as_of,
-      is_active: row.is_active,
-      st:
-        typeof row.market_hash_name === "string" &&
-        row.market_hash_name.startsWith("StatTrak™"),
-    }));
+    const items = dataResult.rows.map((row) => {
+      const minPrice = row.min_price === null ? null : Number(row.min_price);
+      const suggestedPrice =
+        row.suggested_price === null ? null : Number(row.suggested_price);
+      const priceDisplay = getPriceDisplay({
+        min_price: minPrice,
+        suggested_price: suggestedPrice,
+        quantity: row.quantity,
+      });
+
+      return {
+        market_hash_name: row.market_hash_name,
+        min_price: minPrice,
+        suggested_price: suggestedPrice,
+        display_price: priceDisplay.display_price,
+        price_status: priceDisplay.price_status,
+        price_warning: priceDisplay.price_warning,
+        quantity: row.quantity,
+        image_url: row.image_url,
+        weapon: row.weapon,
+        exterior: row.exterior,
+        as_of: row.as_of,
+        is_active: row.is_active,
+        st:
+          typeof row.market_hash_name === "string" &&
+          row.market_hash_name.startsWith("StatTrak™"),
+      };
+    });
 
     res.json({
       total: countResult.rows[0].total,
@@ -135,7 +186,9 @@ router.get("/items", async (req, res, next) => {
       minPrice,
       maxPrice,
       status,
-      sort: "price_asc",
+      sort: sortParams.sort,
+      order: sortParams.order,
+      priceBasis: sortParams.sort === "price" ? "display_price" : null,
       items,
       lastUpdated: latestResult.rows[0].last_updated,
     });

--- a/backend/src/services/priceDisplay.service.js
+++ b/backend/src/services/priceDisplay.service.js
@@ -1,0 +1,65 @@
+const PRICE_OUTLIER_THRESHOLDS = {
+  minSuggestedPrice: 0,
+  minRawPrice: 100,
+  maxMinToSuggestedRatio: 10,
+  maxQuantity: 3,
+};
+
+function toFiniteNumber(value) {
+  if (value === null || value === undefined || value === "") return null;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function isMinPriceOutlier({ min_price, suggested_price, quantity }) {
+  const minPrice = toFiniteNumber(min_price);
+  const suggestedPrice = toFiniteNumber(suggested_price);
+  const qty = quantity === null || quantity === undefined ? null : Number(quantity);
+
+  return (
+    suggestedPrice !== null &&
+    suggestedPrice > PRICE_OUTLIER_THRESHOLDS.minSuggestedPrice &&
+    minPrice !== null &&
+    minPrice > PRICE_OUTLIER_THRESHOLDS.minRawPrice &&
+    minPrice > suggestedPrice * PRICE_OUTLIER_THRESHOLDS.maxMinToSuggestedRatio &&
+    Number.isFinite(qty) &&
+    qty <= PRICE_OUTLIER_THRESHOLDS.maxQuantity
+  );
+}
+
+function getPriceDisplay(row) {
+  const minPrice = toFiniteNumber(row.min_price);
+  const suggestedPrice = toFiniteNumber(row.suggested_price);
+  const isOutlier = isMinPriceOutlier(row);
+
+  return {
+    display_price: isOutlier ? suggestedPrice : minPrice,
+    price_status: isOutlier ? "min_price_outlier" : "normal",
+    price_warning: isOutlier
+      ? "min_price is far above suggested_price for a low-quantity item"
+      : null,
+  };
+}
+
+function getDisplayPriceSql(alias = "l") {
+  return `
+    CASE
+      WHEN ${alias}.suggested_price IS NOT NULL
+        AND ${alias}.suggested_price > ${PRICE_OUTLIER_THRESHOLDS.minSuggestedPrice}
+        AND ${alias}.min_price IS NOT NULL
+        AND ${alias}.min_price > ${PRICE_OUTLIER_THRESHOLDS.minRawPrice}
+        AND ${alias}.min_price > ${alias}.suggested_price * ${PRICE_OUTLIER_THRESHOLDS.maxMinToSuggestedRatio}
+        AND ${alias}.quantity IS NOT NULL
+        AND ${alias}.quantity <= ${PRICE_OUTLIER_THRESHOLDS.maxQuantity}
+      THEN ${alias}.suggested_price
+      ELSE ${alias}.min_price
+    END
+  `;
+}
+
+module.exports = {
+  PRICE_OUTLIER_THRESHOLDS,
+  getDisplayPriceSql,
+  getPriceDisplay,
+  isMinPriceOutlier,
+};

--- a/backend/src/services/skinport.service.js
+++ b/backend/src/services/skinport.service.js
@@ -1,5 +1,6 @@
 const SKINPORT_ITEMS_URL =
   "https://api.skinport.com/v1/items?app_id=730&currency=USD&tradable=1";
+const { getPriceDisplay } = require("./priceDisplay.service");
 
 function toNumber(value) {
   if (value === null || value === undefined || value === "") return null;
@@ -11,6 +12,37 @@ function toInteger(value) {
   if (value === null || value === undefined || value === "") return null;
   const num = Number(value);
   return Number.isInteger(num) ? num : null;
+}
+
+function getPriceValidationWarnings(item, minPrice, suggestedPrice, quantity) {
+  const warnings = [];
+  const priceDisplay = getPriceDisplay({
+    min_price: minPrice,
+    suggested_price: suggestedPrice,
+    quantity,
+  });
+
+  if (minPrice !== null && minPrice < 0) {
+    warnings.push("min_price_negative");
+  }
+
+  if (suggestedPrice !== null && suggestedPrice < 0) {
+    warnings.push("suggested_price_negative");
+  }
+
+  if (minPrice !== null && suggestedPrice !== null && suggestedPrice > minPrice * 100) {
+    warnings.push("suggested_price_much_higher_than_min_price");
+  }
+
+  if (priceDisplay.price_status === "min_price_outlier") {
+    warnings.push("min_price_outlier");
+  }
+
+  if (item.quantity !== null && item.quantity !== undefined && toInteger(item.quantity) === null) {
+    warnings.push("quantity_not_integer");
+  }
+
+  return warnings;
 }
 
 function parseExterior(marketHashName = "") {
@@ -31,6 +63,17 @@ function normalizeSkinportItem(it, asOf) {
     throw new Error("Missing market_hash_name");
   }
 
+  const minPrice = toNumber(it.min_price);
+  const suggestedPrice = toNumber(it.suggested_price);
+  const quantity = toInteger(it.quantity);
+  const imageUrl = it.image_url || it.image || it.icon_url || null;
+  const priceValidationWarnings = getPriceValidationWarnings(
+    it,
+    minPrice,
+    suggestedPrice,
+    quantity
+  );
+
   return {
     market_hash_name: marketHashName,
     item_type: it.item_type || it.type || null,
@@ -38,16 +81,17 @@ function normalizeSkinportItem(it, asOf) {
     rarity_rank: toInteger(it.rarity_rank),
     weapon: parseWeapon(marketHashName),
     exterior: parseExterior(marketHashName),
-    image_url: it.image_url || it.image || it.icon_url || null,
+    image_url: imageUrl,
 
     as_of: asOf,
-    min_price: toNumber(it.min_price),
-    suggested_price: toNumber(it.suggested_price),
-    quantity: toInteger(it.quantity),
+    min_price: minPrice,
+    suggested_price: suggestedPrice,
+    quantity,
 
     raw: {
       ...it,
-      image_url: it.image_url || it.image || it.icon_url || null,
+      image_url: imageUrl,
+      price_validation_warnings: priceValidationWarnings,
     },
   };
 }


### PR DESCRIPTION
## Summary

This PR fixes incorrect user-facing item pricing caused by raw Skinport outlier listings and improves item search behavior.

The reported FlyQuest pricing issue was traced to a separate item, `Sticker Slab | FlyQuest (Holo) | Budapest 2025`, where Skinport returned a raw `min_price` around `$91k` while `suggested_price` was around `$6.54` and quantity was `1`.

The normal sticker item, `Sticker | FlyQuest (Holo) | Budapest 2025`, has sane pricing.

Instead of mutating raw Skinport data, this PR preserves raw prices and adds a safer display price field for API consumers.

---

## Changes

- Adds centralized display price logic in `backend/src/services/priceDisplay.service.js`
- Adds `display_price`, `price_status`, and `price_warning` to `/api/v1/items`
- Preserves raw `min_price`, `suggested_price`, and `quantity`
- Sorts `sort=price` by computed `display_price` instead of raw `min_price`
- Keeps legitimate expensive items ranked correctly when raw and suggested prices are in the same general range
- Improves `q` search to tokenized matching, so searches like `FlyQuest Budapest 2025` match names with punctuation or extra words between tokens
- Preserves existing `image_url` values when Skinport sends null image fields
- Adds `npm run debug:item` for local item price inspection
- Adds raw price validation warnings for suspicious Skinport payloads

---

## Price Outlier Rule

A row is marked as a `min_price_outlier` when:

```js
suggested_price > 0
min_price > 100
min_price > suggested_price * 10
quantity <= 3
```

When this happens:

```js
display_price = suggested_price
price_status = "min_price_outlier"
```

Otherwise:

```js
display_price = min_price
price_status = "normal"
```

This avoids hard-capping expensive items. Legitimate high-value skins and stickers like Katowice 2014 stickers, Dragon Lore, Gungnir, Wild Lotus, and high-tier gloves can still sort correctly when `min_price` and `suggested_price` are in the same general range.

---

## Why this approach

Skinport sometimes returns a valid raw listing that is not a good user-facing market price. For example, a low-liquidity item can have one seller listing it for an absurd amount.

This PR keeps both ideas separate:

- `min_price`: raw Skinport lowest listing
- `suggested_price`: Skinport suggested/reference price
- `display_price`: safer price for UI display and price sorting
- `price_status`: indicates whether the raw `min_price` was treated as an outlier

This lets the app remain transparent while avoiding obviously misleading UI behavior.

---

## Verification

Backend syntax checks:

```bash
cd backend
node --check src/routes/items.routes.js
node --check src/db/items.repository.js
node --check src/services/skinport.service.js
node --check src/services/priceDisplay.service.js
node --check scripts/debug-item.js
```

Verified display-price descending sort:

```bash
curl -s "http://localhost:4000/api/v1/items?limit=25&sort=price&order=desc" \
| jq '[.items[].display_price] as $p | all(range(0; ($p|length)-1); $p[.] >= $p[.+1])'
```

Result:

```text
true
```

Verified FlyQuest outlier handling:

```bash
curl -s "http://localhost:4000/api/v1/items?q=FlyQuest%20%28Holo%29%20Budapest%202025&limit=20" \
| jq '.items[] | {name: .market_hash_name, min_price, suggested_price, display_price, price_status, quantity}'
```

Confirmed:

```text
Sticker | FlyQuest (Holo) | Budapest 2025
min_price: 4.44
suggested_price: 5.41
display_price: 4.44
price_status: normal
quantity: 18

Sticker Slab | FlyQuest (Holo) | Budapest 2025
min_price: 91525.1
suggested_price: 6.54
display_price: 6.54
price_status: min_price_outlier
quantity: 1
```

Verified tokenized search:

```bash
curl -s "http://localhost:4000/api/v1/items?q=FlyQuest%20Budapest%202025&limit=20" \
| jq '.total,.items[]?.market_hash_name'
```

Confirmed this now returns FlyQuest Budapest 2025 items even when the query does not exactly match punctuation or parentheses.

---