### PR TITLE
Optimize item refresh with batch upserts

### DIFF
--- a/backend/src/db/items.repository.js
+++ b/backend/src/db/items.repository.js
@@ -1,6 +1,16 @@
 const pool = require("./pool");
 
-async function upsertItemMetadata(client, item) {
+async function bulkUpsertItemMetadata(client, items) {
+  const payload = items.map((item) => ({
+    market_hash_name: item.market_hash_name,
+    item_type: item.item_type ?? null,
+    rarity: item.rarity ?? null,
+    rarity_rank: item.rarity_rank ?? null,
+    weapon: item.weapon ?? null,
+    exterior: item.exterior ?? null,
+    image_url: item.image_url ?? null,
+  }));
+
   const query = `
     INSERT INTO items (
       market_hash_name,
@@ -11,7 +21,23 @@ async function upsertItemMetadata(client, item) {
       exterior,
       image_url
     )
-    VALUES ($1, $2, $3, $4, $5, $6, $7)
+    SELECT
+      x.market_hash_name,
+      x.item_type,
+      x.rarity,
+      x.rarity_rank,
+      x.weapon,
+      x.exterior,
+      x.image_url
+    FROM jsonb_to_recordset($1::jsonb) AS x(
+      market_hash_name text,
+      item_type text,
+      rarity text,
+      rarity_rank integer,
+      weapon text,
+      exterior text,
+      image_url text
+    )
     ON CONFLICT (market_hash_name)
     DO UPDATE SET
       item_type = EXCLUDED.item_type,
@@ -19,25 +45,33 @@ async function upsertItemMetadata(client, item) {
       rarity_rank = EXCLUDED.rarity_rank,
       weapon = EXCLUDED.weapon,
       exterior = EXCLUDED.exterior,
-      image_url = COALESCE(EXCLUDED.image_url, items.image_url)
-    RETURNING id, market_hash_name;
+      image_url = COALESCE(EXCLUDED.image_url, items.image_url);
   `;
 
-  const values = [
-    item.market_hash_name,
-    item.item_type,
-    item.rarity,
-    item.rarity_rank,
-    item.weapon,
-    item.exterior,
-    item.image_url,
-  ];
-
-  const result = await client.query(query, values);
-  return result.rows[0];
+  await client.query(query, [JSON.stringify(payload)]);
 }
 
-async function upsertItemLatest(client, itemId, item) {
+async function getItemIdsByMarketHashNames(client, marketHashNames) {
+  const query = `
+    SELECT id, market_hash_name
+    FROM items
+    WHERE market_hash_name = ANY($1::text[]);
+  `;
+
+  const result = await client.query(query, [marketHashNames]);
+  return new Map(result.rows.map((row) => [row.market_hash_name, row.id]));
+}
+
+async function bulkUpsertItemLatest(client, rows) {
+  const payload = rows.map((row) => ({
+    item_id: row.item_id,
+    as_of: row.as_of,
+    min_price: row.min_price ?? null,
+    suggested_price: row.suggested_price ?? null,
+    quantity: row.quantity ?? null,
+    raw: row.raw ?? null,
+  }));
+
   const query = `
     INSERT INTO item_latest (
       item_id,
@@ -48,7 +82,22 @@ async function upsertItemLatest(client, itemId, item) {
       raw,
       updated_at
     )
-    VALUES ($1, $2, $3, $4, $5, $6, NOW())
+    SELECT
+      x.item_id,
+      x.as_of,
+      x.min_price,
+      x.suggested_price,
+      x.quantity,
+      x.raw,
+      NOW()
+    FROM jsonb_to_recordset($1::jsonb) AS x(
+      item_id bigint,
+      as_of timestamptz,
+      min_price numeric,
+      suggested_price numeric,
+      quantity integer,
+      raw jsonb
+    )
     ON CONFLICT (item_id)
     DO UPDATE SET
       as_of = EXCLUDED.as_of,
@@ -59,19 +108,19 @@ async function upsertItemLatest(client, itemId, item) {
       updated_at = NOW();
   `;
 
-  const values = [
-    itemId,
-    item.as_of,
-    item.min_price,
-    item.suggested_price,
-    item.quantity,
-    JSON.stringify(item.raw),
-  ];
-
-  await client.query(query, values);
+  await client.query(query, [JSON.stringify(payload)]);
 }
 
-async function insertItemHistory(client, itemId, item) {
+async function bulkInsertItemHistory(client, rows) {
+  const payload = rows.map((row) => ({
+    item_id: row.item_id,
+    as_of: row.as_of,
+    min_price: row.min_price ?? null,
+    suggested_price: row.suggested_price ?? null,
+    quantity: row.quantity ?? null,
+    raw: row.raw ?? null,
+  }));
+
   const query = `
     INSERT INTO item_price_history (
       item_id,
@@ -81,26 +130,32 @@ async function insertItemHistory(client, itemId, item) {
       quantity,
       raw
     )
-    VALUES ($1, $2, $3, $4, $5, $6)
+    SELECT
+      x.item_id,
+      x.as_of,
+      x.min_price,
+      x.suggested_price,
+      x.quantity,
+      x.raw
+    FROM jsonb_to_recordset($1::jsonb) AS x(
+      item_id bigint,
+      as_of timestamptz,
+      min_price numeric,
+      suggested_price numeric,
+      quantity integer,
+      raw jsonb
+    )
     ON CONFLICT (item_id, as_of)
     DO NOTHING;
   `;
 
-  const values = [
-    itemId,
-    item.as_of,
-    item.min_price,
-    item.suggested_price,
-    item.quantity,
-    JSON.stringify(item.raw),
-  ];
-
-  await client.query(query, values);
+  await client.query(query, [JSON.stringify(payload)]);
 }
 
 module.exports = {
   pool,
-  upsertItemMetadata,
-  upsertItemLatest,
-  insertItemHistory,
+  bulkUpsertItemMetadata,
+  getItemIdsByMarketHashNames,
+  bulkUpsertItemLatest,
+  bulkInsertItemHistory,
 };

--- a/backend/src/jobs/refreshItems.job.js
+++ b/backend/src/jobs/refreshItems.job.js
@@ -2,9 +2,10 @@ const { fetchItemsFromSkinport } = require("../services/skinport.service");
 const itemsCache = require("../cache/itemsCache");
 const {
   pool,
-  upsertItemMetadata,
-  upsertItemLatest,
-  insertItemHistory,
+  bulkUpsertItemMetadata,
+  getItemIdsByMarketHashNames,
+  bulkUpsertItemLatest,
+  bulkInsertItemHistory,
 } = require("../db/items.repository");
 
 let refreshInProgress = false;
@@ -17,6 +18,74 @@ function dedupeByMarketHashName(items) {
   return [...map.values()];
 }
 
+function chunkArray(array, size) {
+  const chunks = [];
+  for (let i = 0; i < array.length; i += size) {
+    chunks.push(array.slice(i, i + size));
+  }
+  return chunks;
+}
+
+async function processChunk(client, chunk, chunkIndex, totalChunks) {
+  await client.query("BEGIN");
+  console.log(
+    `[refreshItems] chunk ${chunkIndex + 1}/${totalChunks}: transaction started (${chunk.length} items)`
+  );
+
+  try {
+    await bulkUpsertItemMetadata(client, chunk);
+    console.log(
+      `[refreshItems] chunk ${chunkIndex + 1}/${totalChunks}: metadata upserted`
+    );
+
+    const idMap = await getItemIdsByMarketHashNames(
+      client,
+      chunk.map((item) => item.market_hash_name)
+    );
+
+    const rows = chunk.map((item) => {
+      const itemId = idMap.get(item.market_hash_name);
+
+      if (!itemId) {
+        throw new Error(
+          `Missing item_id for market_hash_name: ${item.market_hash_name}`
+        );
+      }
+
+      return {
+        item_id: itemId,
+        as_of: item.as_of,
+        min_price: item.min_price,
+        suggested_price: item.suggested_price,
+        quantity: item.quantity,
+        raw: item.raw ?? item,
+      };
+    });
+
+    await bulkUpsertItemLatest(client, rows);
+    console.log(
+      `[refreshItems] chunk ${chunkIndex + 1}/${totalChunks}: latest upserted`
+    );
+
+    await bulkInsertItemHistory(client, rows);
+    console.log(
+      `[refreshItems] chunk ${chunkIndex + 1}/${totalChunks}: history inserted`
+    );
+
+    await client.query("COMMIT");
+    console.log(
+      `[refreshItems] chunk ${chunkIndex + 1}/${totalChunks}: transaction committed`
+    );
+  } catch (err) {
+    await client.query("ROLLBACK");
+    console.error(
+      `[refreshItems] chunk ${chunkIndex + 1}/${totalChunks}: transaction rolled back`,
+      err
+    );
+    throw err;
+  }
+}
+
 async function refreshItems() {
   if (refreshInProgress) {
     console.log("[refreshItems] skipped: refresh already running");
@@ -26,6 +95,8 @@ async function refreshItems() {
   refreshInProgress = true;
   console.log("[refreshItems] started");
 
+  let client;
+
   try {
     console.log("[refreshItems] fetching from Skinport...");
     const fetchedItems = await fetchItemsFromSkinport();
@@ -34,39 +105,32 @@ async function refreshItems() {
     const items = dedupeByMarketHashName(fetchedItems);
     console.log(`[refreshItems] deduped to ${items.length} unique items`);
 
+    const chunks = chunkArray(items, 500);
+    console.log(`[refreshItems] split into ${chunks.length} chunks`);
+
     console.log("[refreshItems] connecting to Postgres...");
-    const client = await pool.connect();
+    client = await pool.connect();
     console.log("[refreshItems] connected to Postgres");
 
-    try {
-      await client.query("BEGIN");
-      console.log("[refreshItems] transaction started");
-
-      for (const item of items) {
-        const itemRow = await upsertItemMetadata(client, item);
-        await upsertItemLatest(client, itemRow.id, item);
-        await insertItemHistory(client, itemRow.id, item);
-      }
-
-      await client.query("COMMIT");
-      console.log("[refreshItems] transaction committed");
-    } catch (err) {
-      await client.query("ROLLBACK");
-      console.error("[refreshItems] transaction rolled back:", err.message);
-      throw err;
-    } finally {
-      client.release();
-      console.log("[refreshItems] Postgres client released");
+    for (let i = 0; i < chunks.length; i++) {
+      await processChunk(client, chunks[i], i, chunks.length);
     }
 
     itemsCache.setItems(items);
 
     console.log(
-      `[refreshItems] OK: wrote ${items.length} unique items to Postgres and cached them @ ${itemsCache.getLastUpdated().toISOString()}`
+      `[refreshItems] OK: wrote ${items.length} unique items to Postgres and cached them @ ${itemsCache
+        .getLastUpdated()
+        .toISOString()}`
     );
   } catch (err) {
-    console.error("[refreshItems] FAILED:", err.message);
+    console.error("[refreshItems] FAILED:", err);
   } finally {
+    if (client) {
+      client.release();
+      console.log("[refreshItems] Postgres client released");
+    }
+
     refreshInProgress = false;
     console.log("[refreshItems] finished");
   }


### PR DESCRIPTION
## Summary
Optimizes the Skinport refresh pipeline by replacing per-item database writes with chunked batch upserts. Before doing this, inserting into database not efficient enough in a deployed db environment. Before, we ran 75k+ queries for every refresh job. this breaks that into 49 query batches.

## Changes
- Batch upserts stable item metadata into `items`
- Batch upserts current market state into `item_latest`
- Batch inserts snapshots into `item_price_history`
- Processes refreshes in chunks of 500 items
- Keeps refresh writes transactional per chunk

## Testing
- Verified `/api/v1/health`
- Verified `/api/v1/db`
- Verified `/api/v1/items?limit=5`
- Verified `status=active`
- Verified `status=all`
- Verified text search with `q=ak-47`
- Verified weapon filter with `weapon=AK-47`
- Verified StatTrak filter with `st=true`
- Verified price range filter with `minPrice=10&maxPrice=100`
- Ran refresh against local Postgres
- Confirmed 24,776 items and 24,776 latest rows
- Confirmed 8,619,316 history rows remain valid
- Confirmed no duplicate items
- Confirmed no duplicate latest rows
- Confirmed no duplicate history snapshots
- Confirmed no orphan latest/history rows
- Confirmed no bad/null item names
- Confirmed no invalid quantity/as_of rows